### PR TITLE
Fix array slice when using negative indexes

### DIFF
--- a/src/colony/lua/colony-js.lua
+++ b/src/colony/lua/colony-js.lua
@@ -482,6 +482,15 @@ arr_proto.slice = function (this, start, len)
   if not this then
     return js_arr(a, 0)
   end
+
+  if start < 0 then
+    start = this.length + start
+  end
+
+  if len < 0 then
+    len = this.length + len
+  end
+
   if len == nil then
     len = this.length or 0
   end
@@ -2044,7 +2053,7 @@ function decodeURIComponent (this, str)
   local utf8 = string.gsub (str, "%%(%x%x)", function(h)
     return string.char(tonumber(h,16))
   end)
-  return tm.str_from_utf8(utf8) 
+  return tm.str_from_utf8(utf8)
 end
 
 

--- a/test/suite/array.js
+++ b/test/suite/array.js
@@ -1,6 +1,6 @@
 var tap = require('../tap');
 
-tap.count(56);
+tap.count(59);
 
 function arreq (a, b) {
 	if (a.length != b.length) {
@@ -58,6 +58,9 @@ tap.ok([0, 0, 0, 0, 0, 0].length == 6);
 tap.ok(arreq([0, 1, 2, 3, 4, 5].slice(0, 5), [0, 1, 2, 3, 4]))
 tap.ok(arreq([0, 0, 0, 0, 0, 0].slice(0, 5), [0, 0, 0, 0, 0]));
 tap.ok(arreq([0, 1, 2, 3, 4, 5].slice(1), [1, 2, 3, 4, 5]), 'slice(1) returns full array')
+tap.ok(arreq([1,2,3].slice(-1), [3]), 'slice -1 returns the last element in an array');
+tap.ok(arreq([1,2,3].slice(-2), [2,3]), 'slice -2 returns the last two elements in an array');
+tap.ok(arreq([1,2,3].slice(0,-1), [1,2]), 'slice 0,-1 returns the everything except the last');
 
 
 var a = new Array(50);


### PR DESCRIPTION
When calling `arr.slice(-1)` the output was getting `[undefined,
*rest]`. The desired behavior would be to get the last element. The
array should start slicing at the element that many back from the end of
the array. In order to fix the issue if the start or end of the slice
are negative they are replaced by the length + (-num). This gives the
desired effect.

[Closes #695]
Amos King @adkron <amos@binarynoggin.com>