### PR TITLE
Support TLS `ca` and `rejectUnauthorized` options (connect to self-signed servers)

### DIFF
--- a/src/colony/colony.c
+++ b/src/colony/colony.c
@@ -80,7 +80,7 @@ int colony_isbuffer (lua_State *L, int index)
     if (!lua_isnil(L, -1)) {
       ret = 1;
     }
-    lua_pop(L, 1);
+    lua_pop(L, 2);
   }
   return ret;
 }

--- a/src/colony/colony.c
+++ b/src/colony/colony.c
@@ -57,6 +57,21 @@ int colony_isarray (lua_State* L, int index)
   return ret;
 }
 
+void colony_array_length (lua_State* L, int pos)
+{
+  // TODO fix
+  lua_getfield(L, pos, "length");
+}
+
+size_t colony_array_length_i (lua_State* L, int pos)
+{
+  // TODO fix
+  lua_getfield(L, pos, "length");
+  size_t ret = (size_t) lua_tonumber(L, -1);
+  lua_pop(L, 1);
+  return ret;
+}
+
 int colony_isbuffer (lua_State *L, int index)
 {
   int ret = 0;

--- a/src/colony/colony.h
+++ b/src/colony/colony.h
@@ -41,5 +41,7 @@ uint8_t* colony_tobuffer (lua_State* L, int index, size_t* buf_len);
 void colony_ipc_emit (lua_State* L, char *type, void* data, size_t size);
 int colony_isbuffer (lua_State *L, int index);
 int colony_isarray (lua_State* L, int index);
+void colony_array_length (lua_State* L, int pos);
+size_t colony_array_length_i (lua_State* L, int pos);
 
 LUALIB_API const char *colony_tolstring (lua_State *L, int idx, size_t *len);

--- a/src/colony/colony_runtime.c
+++ b/src/colony/colony_runtime.c
@@ -154,7 +154,6 @@ static int runtime_panic (lua_State *L)
  * colony lua methods
  */
 
-typedef struct dir_reg { const char *path; const unsigned char *src; unsigned int len; } dir_reg_t;
 extern dir_reg_t dir_runtime_lib[];
 extern dir_reg_t dir_builtin[];
 

--- a/src/colony/lua_rapidjson.c
+++ b/src/colony/lua_rapidjson.c
@@ -18,21 +18,6 @@
 #include "lua_rapidjson.h"
 #include "../tm_json.h"
 
-void colony_array_length (lua_State* L, int pos)
-{
-  // TODO fix
-  lua_getfield(L, pos, "length");
-}
-
-size_t colony_array_length_i (lua_State* L, int pos)
-{
-  // TODO fix
-  lua_getfield(L, pos, "length");
-  size_t ret = (size_t) lua_tonumber(L, -1);
-  lua_pop(L, 1);
-  return ret;
-}
-
 // Simple methods for referring to the state maintained carried by JSON parsing.
 
 static void state_key_get (lua_State* L) { lua_pushvalue(L, 3); }

--- a/src/colony/lua_tm.c
+++ b/src/colony/lua_tm.c
@@ -309,7 +309,7 @@ static int l_tm_ssl_context_create (lua_State* L)
   dir_reg_t* cert_bundle = NULL;
   if (colony_isarray(L, 2)) {
     size_t len = colony_array_length_i(L, 2);
-    cert_bundle = calloc(len + 1, sizeof(dir_reg_t));   // includes end marker
+    cert_bundle = calloc(len + 1, sizeof(dir_reg_t));   // includes \0-filled end marker
     for (size_t i = 0; i < len; i++) {
       lua_pushinteger(L, i);
       lua_gettable(L, 2);
@@ -323,7 +323,6 @@ static int l_tm_ssl_context_create (lua_State* L)
       cert_bundle[i].path = "custom.ca";
       lua_pop(L, 1);
     }
-    memset(&cert_bundle[len], 0, sizeof(dir_reg_t));
   }
   
   int res = tm_ssl_context_create(check_certs, cert_bundle, &ctx);

--- a/src/colony/lua_tm.c
+++ b/src/colony/lua_tm.c
@@ -305,9 +305,9 @@ static int l_tm_tcp_accept (lua_State* L)
 static int l_tm_ssl_context_create (lua_State* L)
 {
   tm_ssl_ctx_t ctx;
-
-  int res = tm_ssl_context_create(&ctx);
-
+  bool check_certs = lua_toboolean(L, 1);
+  
+  int res = tm_ssl_context_create(check_certs, &ctx);
   if (res != 0) {
     lua_pushnil(L);
   } else {

--- a/src/colony/lua_tm.c
+++ b/src/colony/lua_tm.c
@@ -307,7 +307,7 @@ static int l_tm_ssl_context_create (lua_State* L)
   tm_ssl_ctx_t ctx;
   bool check_certs = lua_toboolean(L, 1);
   
-  int res = tm_ssl_context_create(check_certs, &ctx);
+  int res = tm_ssl_context_create(check_certs, NULL, &ctx);
   if (res != 0) {
     lua_pushnil(L);
   } else {

--- a/src/colony/lua_tm.c
+++ b/src/colony/lua_tm.c
@@ -11,6 +11,7 @@
 #include <lauxlib.h>
 #include <lualib.h>
 #include <math.h>
+#include <assert.h>
 
 #include "tm.h"
 #include "colony.h"
@@ -313,12 +314,9 @@ static int l_tm_ssl_context_create (lua_State* L)
     for (size_t i = 0; i < len; i++) {
       lua_pushinteger(L, i);
       lua_gettable(L, 2);
+      assert(colony_isbuffer(L, -1));
       size_t src_len;
-      if (colony_isbuffer(L, -1)) {
-        cert_bundle[i].src = colony_tobuffer(L, -1, &src_len);
-      } else {
-        cert_bundle[i].src = (const unsigned char *) colony_tolutf8(L, -1, &src_len);
-      }
+      cert_bundle[i].src = colony_tobuffer(L, -1, &src_len);
       cert_bundle[i].len = (unsigned int) src_len;
       cert_bundle[i].path = "custom.ca";
       lua_pop(L, 1);

--- a/src/colony/lua_tm.c
+++ b/src/colony/lua_tm.c
@@ -306,8 +306,28 @@ static int l_tm_ssl_context_create (lua_State* L)
 {
   tm_ssl_ctx_t ctx;
   bool check_certs = lua_toboolean(L, 1);
+  dir_reg_t* cert_bundle = NULL;
+  if (colony_isarray(L, 2)) {
+    size_t len = colony_array_length_i(L, 2);
+    cert_bundle = calloc(len + 1, sizeof(dir_reg_t));   // includes end marker
+    for (size_t i = 0; i < len; i++) {
+      lua_pushinteger(L, i);
+      lua_gettable(L, 2);
+      size_t src_len;
+      if (colony_isbuffer(L, -1)) {
+        cert_bundle[i].src = colony_tobuffer(L, -1, &src_len);
+      } else {
+        cert_bundle[i].src = (const unsigned char *) colony_tolutf8(L, -1, &src_len);
+      }
+      cert_bundle[i].len = (unsigned int) src_len;
+      cert_bundle[i].path = "custom.ca";
+      lua_pop(L, 1);
+    }
+    memset(&cert_bundle[len], 0, sizeof(dir_reg_t));
+  }
   
-  int res = tm_ssl_context_create(check_certs, NULL, &ctx);
+  int res = tm_ssl_context_create(check_certs, cert_bundle, &ctx);
+  if (cert_bundle) free(cert_bundle);
   if (res != 0) {
     lua_pushnil(L);
   } else {

--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -148,8 +148,15 @@ TCPSocket.prototype.connect = function (/*options | [port], [host], [cb]*/) {
   function setUpConnection(ip) {
     if (self.socket == null) {
       if (self._secure) {
+        var custom_certs = null;
         self._ssl_checkCerts = (opts.rejectUnauthorized !== false);
-        self._ssl_ctx = tm.ssl_context_create(self._ssl_checkCerts, opts.ca);
+        if (opts.ca) custom_certs = opts.ca.map(function (pem_data) {
+            // TODO: review PEM specs and axTLS needs; make more thorough if needed
+            return Buffer(pem_data.toString().split('\n').filter(function (line) {
+                return line && line.indexOf('-----') !== 0;
+            }).join(''), 'base64');
+        });
+        self._ssl_ctx = tm.ssl_context_create(self._ssl_checkCerts, custom_certs);
       }
       self.socket = tm.tcp_open();
     }

--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -149,7 +149,7 @@ TCPSocket.prototype.connect = function (/*options | [port], [host], [cb]*/) {
     if (self.socket == null) {
       if (self._secure) {
         self._ssl_checkCerts = (opts.rejectUnauthorized !== false);
-        self._ssl_ctx = tm.ssl_context_create(self._ssl_checkCerts);
+        self._ssl_ctx = tm.ssl_context_create(self._ssl_checkCerts, opts.ca);
       }
       self.socket = tm.tcp_open();
     }

--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -37,22 +37,6 @@ function isPipeName(s) {
 function toNumber(x) { return (x = Number(x)) >= 0 ? x : false; }
 
 /**
- * ssl
- */
-
-var ssl_ctx = null;
-
-function ensureSSLCtx () {
-  if (!tm.ssl_context_create) {
-    throw new Error("SSL/TLS is not supported in this version.");
-  }
-  if (ssl_ctx == null) {
-    ssl_ctx = tm.ssl_context_create();
-  }
-}
-
-
-/**
  * TCPSocket
  */
 
@@ -163,7 +147,7 @@ TCPSocket.prototype.connect = function (/*options | [port], [host], [cb]*/) {
 
   function setUpConnection(ip) {
     if (self.socket == null) {
-      if (self._secure) ensureSSLCtx();
+      if (self._secure) self._ssl_ctx = tm.ssl_context_create();
       self.socket = tm.tcp_open();
     }
 
@@ -245,7 +229,7 @@ TCPSocket.prototype.connect = function (/*options | [port], [host], [cb]*/) {
         }, 100);
 
         function createSession() {
-          var _ = tm.ssl_session_create(ssl_ctx, self.socket, hostname)
+          var _ = tm.ssl_session_create(self._ssl_ctx, self.socket, hostname)
             , ssl = _[0]
             , ret = _[1]
             ;

--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -147,7 +147,8 @@ TCPSocket.prototype.connect = function (/*options | [port], [host], [cb]*/) {
 
   function setUpConnection(ip) {
     if (self.socket == null) {
-      if (self._secure) self._ssl_ctx = tm.ssl_context_create();
+      var checkCerts = (opts.rejectUnauthorized !== false);
+      if (self._secure) self._ssl_ctx = tm.ssl_context_create(checkCerts);
       self.socket = tm.tcp_open();
     }
 
@@ -522,10 +523,10 @@ TCPSocket.prototype.setNoDelay = function (val) {
   if (val) console.warn("Ignoring call to setNoDelay. TCP_NODELAY socket option not supported.");
 };
 
-function connect (port, host, callback, _secure) {
+function connect (options, callback, _secure) {
   var client = new TCPSocket(null, _secure);
   var args = Array.prototype.slice.call(arguments);
-  if (args.length === 4) args.pop();      // drop _secure param
+  if (args.length === 3) args.pop();      // drop _secure param
   TCPSocket.prototype.connect.apply(client, args);
   return client;
 };

--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -147,8 +147,10 @@ TCPSocket.prototype.connect = function (/*options | [port], [host], [cb]*/) {
 
   function setUpConnection(ip) {
     if (self.socket == null) {
-      var checkCerts = (opts.rejectUnauthorized !== false);
-      if (self._secure) self._ssl_ctx = tm.ssl_context_create(checkCerts);
+      if (self._secure) {
+        self._ssl_checkCerts = (opts.rejectUnauthorized !== false);
+        self._ssl_ctx = tm.ssl_context_create(self._ssl_checkCerts);
+      }
       self.socket = tm.tcp_open();
     }
 
@@ -275,7 +277,7 @@ TCPSocket.prototype.connect = function (/*options | [port], [host], [cb]*/) {
             }
           }
 
-          if (!tls.checkServerIdentity(host, cert)) {
+          if (self._ssl_checkCerts && !tls.checkServerIdentity(host, cert)) {
             return self.emit('error', new Error('Hostname/IP doesn\'t match certificate\'s altnames'));
           }
 

--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -277,7 +277,7 @@ TCPSocket.prototype.connect = function (/*options | [port], [host], [cb]*/) {
                 }
                 altnames.push(altname);
               }
-              return 'DNS:' + altnames.join(', DNS:');
+              return altnames.map(function (n) { return 'DNS:' + n; }).join(', ');
             })(),
             subject: {
               CN: tm.ssl_session_cn(ssl)[0]

--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -536,11 +536,17 @@ TCPSocket.prototype.setNoDelay = function (val) {
   if (val) console.warn("Ignoring call to setNoDelay. TCP_NODELAY socket option not supported.");
 };
 
-function connect (options, callback, _secure) {
-  var client = new TCPSocket(null, _secure);
-  var args = Array.prototype.slice.call(arguments);
-  if (args.length === 3) args.pop();      // drop _secure param
-  TCPSocket.prototype.connect.apply(client, args);
+function connect (port, host, callback) {
+  var client = new TCPSocket(null);
+  TCPSocket.prototype.connect.apply(client, arguments);
+  return client;
+};
+
+// HACK: this is a quick solution to the regressions introduced by 5fb859605b183b70b246328bff24f4e4f8b50dab
+//       a more complete solution is implemented in a different PR: c015017492980271fa583fce57d798de26a12dab
+function _secureConnect (options, callback) {
+  var client = new TCPSocket(null, true);
+  TCPSocket.prototype.connect.apply(client, arguments);
   return client;
 };
 
@@ -653,6 +659,7 @@ function createServer (opts, onsocket) {
 exports.isIP = isIP;
 exports.isIPv4 = isIPv4;
 exports.connect = exports.createConnection = connect;
+exports._secureConnect = _secureConnect;
 exports.createServer = createServer;
 exports.Socket = TCPSocket;
 exports.Server = TCPServer;

--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -258,7 +258,7 @@ TCPSocket.prototype.connect = function (/*options | [port], [host], [cb]*/) {
             }
           }
 
-          var cert = {
+          self._ssl_cert = {
             subjectaltname: (function () {
               var altnames = [];
               for (var i = 0; ; i++) {
@@ -275,9 +275,9 @@ TCPSocket.prototype.connect = function (/*options | [port], [host], [cb]*/) {
             subject: {
               CN: tm.ssl_session_cn(ssl)[0]
             }
-          }
+          };
 
-          if (self._ssl_checkCerts && !tls.checkServerIdentity(host, cert)) {
+          if (self._ssl_checkCerts && !tls.checkServerIdentity(host, self._ssl_cert)) {
             return self.emit('error', new Error('Hostname/IP doesn\'t match certificate\'s altnames'));
           }
 
@@ -517,7 +517,11 @@ TCPSocket.prototype._restartTimeout = function () {
   this._timeoutWatchdog = (self._timeout) ? setTimeout(function () {
     self.emit('timeout');
   }, self._timeout) : null;
-}
+};
+
+TCPSocket.prototype.getPeerCertificate = function () {
+  return this._ssl_cert || null;
+};
 
 
 // NOTE: CC3K may not support? http://e2e.ti.com/support/wireless_connectivity/f/851/p/349461/1223801.aspx#1223801

--- a/src/colony/modules/tls.js
+++ b/src/colony/modules/tls.js
@@ -18,7 +18,7 @@ exports.connect = function connect () {
   var arguments = normalizeConnectArgs(arguments);
   var options = arguments[0];
   var callback = arguments[1];
-  return net.connect(options.port, options.host, callback, true);
+  return net.connect(options, callback, true);
 }
 
 function normalizeConnectArgs(listArgs) {

--- a/src/colony/modules/tls.js
+++ b/src/colony/modules/tls.js
@@ -18,7 +18,7 @@ exports.connect = function connect () {
   var arguments = normalizeConnectArgs(arguments);
   var options = arguments[0];
   var callback = arguments[1];
-  return net.connect(options, callback, true);
+  return net._secureConnect(options, callback);
 }
 
 function normalizeConnectArgs(listArgs) {

--- a/src/tm.h
+++ b/src/tm.h
@@ -177,7 +177,7 @@ int tm_inflate_end (tm_inflate_t _inflator, uint8_t* out, size_t out_len, size_t
 typedef void* tm_ssl_ctx_t;
 typedef void* tm_ssl_session_t;
 
-int tm_ssl_context_create (tm_ssl_ctx_t* ctx);
+int tm_ssl_context_create (bool check_certs, tm_ssl_ctx_t* ctx);
 int tm_ssl_context_free (tm_ssl_ctx_t *ctx);
 int tm_ssl_session_create (tm_ssl_session_t* session, tm_ssl_ctx_t ctx, tm_socket_t client_fd, const char* host_name);
 int tm_ssl_session_altname (tm_ssl_session_t* session, size_t index, const char** altname);

--- a/src/tm.h
+++ b/src/tm.h
@@ -176,8 +176,9 @@ int tm_inflate_end (tm_inflate_t _inflator, uint8_t* out, size_t out_len, size_t
 
 typedef void* tm_ssl_ctx_t;
 typedef void* tm_ssl_session_t;
+typedef struct dir_reg { const char *path; const unsigned char *src; unsigned int len; } dir_reg_t;
 
-int tm_ssl_context_create (bool check_certs, tm_ssl_ctx_t* ctx);
+int tm_ssl_context_create (bool check_certs, dir_reg_t cert_bundle[], tm_ssl_ctx_t* ctx);
 int tm_ssl_context_free (tm_ssl_ctx_t *ctx);
 int tm_ssl_session_create (tm_ssl_session_t* session, tm_ssl_ctx_t ctx, tm_socket_t client_fd, const char* host_name);
 int tm_ssl_session_altname (tm_ssl_session_t* session, size_t index, const char** altname);

--- a/src/tm_ssl.c
+++ b/src/tm_ssl.c
@@ -50,10 +50,9 @@ int tm_ssl_read (tm_ssl_session_t ssl, uint8_t *buf, size_t *buf_len)
     }
 }
 
-typedef struct dir_reg { const char *path; const unsigned char *src; unsigned int len; } dir_reg_t;
 extern dir_reg_t cacert_bundle[];
 
-int tm_ssl_context_create (bool check_certs, tm_ssl_ctx_t* ctx)
+int tm_ssl_context_create (bool check_certs, dir_reg_t cert_bundle[], tm_ssl_ctx_t* ctx)
 {
 #ifdef TLS_VERBOSE
     uint32_t options = SSL_DISPLAY_CERTS;
@@ -62,6 +61,9 @@ int tm_ssl_context_create (bool check_certs, tm_ssl_ctx_t* ctx)
 #endif
     if (!check_certs) {
         options |= SSL_SERVER_VERIFY_LATER;
+    }
+    if (!cert_bundle) {
+      cert_bundle = cacert_bundle;
     }
 
     SSL_CTX *ssl_ctx;
@@ -72,8 +74,8 @@ int tm_ssl_context_create (bool check_certs, tm_ssl_ctx_t* ctx)
     }
 
     // Load lib/*.lua files into memory.
-    for (int i = 0; cacert_bundle[i].path != NULL; i++) {
-        if (add_cert_auth(ssl_ctx, cacert_bundle[i].src, 1)) {
+    for (int i = 0; cert_bundle[i].path != NULL; i++) {
+        if (add_cert_auth(ssl_ctx, cert_bundle[i].src, 1)) {
             TLS_DEBUG("Invalid CA cert bundle at index %d, aborting.\n", i);
             return -1;
         }

--- a/src/tm_ssl.c
+++ b/src/tm_ssl.c
@@ -75,7 +75,7 @@ int tm_ssl_context_create (bool check_certs, dir_reg_t cert_bundle[], tm_ssl_ctx
 
     // Load lib/*.lua files into memory.
     for (int i = 0; cert_bundle[i].path != NULL; i++) {
-        if (add_cert_auth(ssl_ctx, cert_bundle[i].src, 1)) {
+        if (add_cert_auth(ssl_ctx, cert_bundle[i].src, cert_bundle[i].len)) {
             TLS_DEBUG("Invalid CA cert bundle at index %d, aborting.\n", i);
             return -1;
         }

--- a/src/tm_ssl.c
+++ b/src/tm_ssl.c
@@ -53,13 +53,16 @@ int tm_ssl_read (tm_ssl_session_t ssl, uint8_t *buf, size_t *buf_len)
 typedef struct dir_reg { const char *path; const unsigned char *src; unsigned int len; } dir_reg_t;
 extern dir_reg_t cacert_bundle[];
 
-int tm_ssl_context_create (tm_ssl_ctx_t* ctx)
+int tm_ssl_context_create (bool check_certs, tm_ssl_ctx_t* ctx)
 {
 #ifdef TLS_VERBOSE
     uint32_t options = SSL_DISPLAY_CERTS;
 #else
     uint32_t options = 0;
 #endif
+    if (!check_certs) {
+        options |= SSL_SERVER_VERIFY_LATER;
+    }
 
     SSL_CTX *ssl_ctx;
     if ((ssl_ctx = ssl_ctx_new(options, SSL_DEFAULT_CLNT_SESS)) == NULL)

--- a/src/tm_ssl.c
+++ b/src/tm_ssl.c
@@ -73,10 +73,10 @@ int tm_ssl_context_create (bool check_certs, dir_reg_t cert_bundle[], tm_ssl_ctx
         return -1;
     }
 
-    // Load lib/*.lua files into memory.
-    for (int i = 0; cert_bundle[i].path != NULL; i++) {
-        if (add_cert_auth(ssl_ctx, cert_bundle[i].src, cert_bundle[i].len)) {
-            TLS_DEBUG("Invalid CA cert bundle at index %d, aborting.\n", i);
+    for (size_t i = 0; cert_bundle[i].path != NULL; i++) {
+//printf("Adding cert #%zu: %s <%u>\n", i, cert_bundle[i].src, cert_bundle[i].len);
+        if (add_cert_auth(ssl_ctx, cert_bundle[i].src, 1)) {
+            TLS_DEBUG("Invalid CA cert bundle at index %zu, aborting.\n", i);
             return -1;
         }
     }

--- a/test/suite/tls.js
+++ b/test/suite/tls.js
@@ -6,6 +6,7 @@ tap.count(3);
 var options = {
   host : 'www.google.com',
   port : 443,
+  //rejectUnauthorized: false
 };
 
 var socket = tls.connect(options, function connected() {


### PR DESCRIPTION
This improves the TLS module's node.js compatibility regarding (remote) server certificate handling (i.e. when Tessel is the client).

- support `{rejectUnauthorized:false}` option, aka enable cheap MITM attacks [useful for development and careless people]
- support custom CA lists [useful for validating self-signed certs or own set of trusted roots]
- `tlsSocket.getPeerCertificate()` is now sort of implemented for non-detailed info (even that is probably not 100% compatible with whatever undocumented fields node.js provides, but presumedly better than nuffins)
- also fixed a bug where a server certificate that didn't contain subjectaltnames would always be rejected