### PR TITLE
Adds support for arguments.callee.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "async": "~0.2.9",
     "bindings": "~1.2.0",
-    "colony-compiler": "~0.6.23",
+    "colony-compiler": "0.7.x",
     "mkdirp": "~0.3.5",
     "semver": "^4.1.0"
   },

--- a/src/colony/lua/colony-init.lua
+++ b/src/colony/lua/colony-init.lua
@@ -506,7 +506,7 @@ end
 
 -- arguments objects
 
-function js_arguments (...)
+function js_arguments (strict, callee, ...)
   local a, len = {}, select('#', ...)
   for i=1,len do
     local val, _ = select(i, ...)
@@ -515,6 +515,13 @@ function js_arguments (...)
 
   local obj = global._obj(a);
   obj.length = len
+  if strict then
+    js_define_getter(obj, 'callee', function (this)
+      error(js_new(global.TypeError, '\'caller\', \'callee\', and \'arguments\' properties may not be accessed on strict mode functions or the arguments objects for calls to them'))
+    end)
+  else
+    obj.callee = callee
+  end
   get_unique_metatable(obj).arguments = true
   return obj
 end

--- a/test/issues/issue-runtime-573.js
+++ b/test/issues/issue-runtime-573.js
@@ -1,0 +1,10 @@
+var tap = require('../tap');
+
+tap.count(1);
+
+iCalled();
+
+function iCalled() { callMeMaybe(); }
+function callMeMaybe() {
+    tap.ok(arguments.callee== callMeMaybe,'function callee');
+}


### PR DESCRIPTION
Supplants https://github.com/tessel/runtime/pull/597 .