### PR TITLE
Avoid writing to an SSL context if it looks like a read is in progress

### DIFF
--- a/src/colony/lua_tm.c
+++ b/src/colony/lua_tm.c
@@ -405,6 +405,16 @@ static int l_tm_ssl_session_free (lua_State* L)
   return 1;
 }
 
+static int l_tm_ssl_writeable (lua_State* L)
+{
+  tm_ssl_session_t session = (tm_ssl_session_t) lua_touserdata(L, 1);
+  
+  bool res = tm_ssl_writeable(session);
+  
+  lua_pushboolean(L, res);
+  return 1;
+}
+
 
 static int l_tm_ssl_write (lua_State* L)
 {
@@ -1408,6 +1418,7 @@ LUALIB_API int luaopen_tm (lua_State *L)
     { "ssl_session_altname", l_tm_ssl_session_altname },
     { "ssl_session_cn", l_tm_ssl_session_cn },
     { "ssl_session_free", l_tm_ssl_session_free },
+    { "ssl_writeable", l_tm_ssl_writeable },
     { "ssl_write", l_tm_ssl_write },
     { "ssl_read", l_tm_ssl_read },
 #endif

--- a/src/colony/lua_tm.c
+++ b/src/colony/lua_tm.c
@@ -409,7 +409,7 @@ static int l_tm_ssl_writeable (lua_State* L)
 {
   tm_ssl_session_t session = (tm_ssl_session_t) lua_touserdata(L, 1);
   
-  bool res = tm_ssl_writeable(session);
+  int res = tm_ssl_writeable(session);
   
   lua_pushboolean(L, res);
   return 1;

--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -318,12 +318,6 @@ TCPSocket.prototype._read = function (size) {
 TCPSocket.prototype.__listen = function () {
   var self = this;
   this.__listenid = setTimeout(function loop () {
-    if (self._sending) {
-      // retry soon
-      setTimeout(loop, 100);
-      return;
-    }
-
     self.__listenid = null;
     // ~HACK: set a watchdog to fire end event if not re-polled
     var failsafeEnd = setImmediate(function () {

--- a/src/colony/modules/net.js
+++ b/src/colony/modules/net.js
@@ -385,7 +385,9 @@ TCPSocket.prototype.__send = function (cb) {
 
     var ret = null;
     if (self._ssl) {
-      ret = tm.ssl_write(self._ssl, buf, buf.length);
+      // HACK: if socket isn't writable due to in-progress incoming data, feign EAGAIN
+      //       (axTLS's ssl_write clobbers state that ssl_read may store between calls)
+      ret = (tm.ssl_writeable(self._ssl)) ? tm.ssl_write(self._ssl, buf, buf.length) : -11;
     } else {
       // HACK/TODO: invert return value to match logic below (but AFAICT it used to always get -1 from this TCP path anyway??!)
       ret = -tm.tcp_write(self.socket, buf, buf.length);

--- a/src/tm.h
+++ b/src/tm.h
@@ -184,6 +184,7 @@ int tm_ssl_session_create (tm_ssl_session_t* session, tm_ssl_ctx_t ctx, tm_socke
 int tm_ssl_session_altname (tm_ssl_session_t* session, size_t index, const char** altname);
 int tm_ssl_session_cn (tm_ssl_session_t* session, const char** cn);
 int tm_ssl_session_free (tm_ssl_session_t *session);
+bool tm_ssl_writeable (tm_ssl_session_t ssl);
 int tm_ssl_write (tm_ssl_session_t ssl, const uint8_t *buf, size_t *buf_len);
 int tm_ssl_read (tm_ssl_session_t ssl, uint8_t *buf, size_t *buf_len);
 

--- a/src/tm.h
+++ b/src/tm.h
@@ -184,7 +184,7 @@ int tm_ssl_session_create (tm_ssl_session_t* session, tm_ssl_ctx_t ctx, tm_socke
 int tm_ssl_session_altname (tm_ssl_session_t* session, size_t index, const char** altname);
 int tm_ssl_session_cn (tm_ssl_session_t* session, const char** cn);
 int tm_ssl_session_free (tm_ssl_session_t *session);
-bool tm_ssl_writeable (tm_ssl_session_t ssl);
+int tm_ssl_writeable (tm_ssl_session_t ssl);
 int tm_ssl_write (tm_ssl_session_t ssl, const uint8_t *buf, size_t *buf_len);
 int tm_ssl_read (tm_ssl_session_t ssl, uint8_t *buf, size_t *buf_len);
 

--- a/src/tm_ssl.c
+++ b/src/tm_ssl.c
@@ -59,6 +59,7 @@ int tm_ssl_context_create (bool check_certs, dir_reg_t cert_bundle[], tm_ssl_ctx
 #else
     uint32_t options = 0;
 #endif
+    //options |= SSL_DISPLAY_STATES | SSL_DISPLAY_BYTES;
     if (!check_certs) {
         options |= SSL_SERVER_VERIFY_LATER;
     }

--- a/src/tm_ssl.c
+++ b/src/tm_ssl.c
@@ -22,6 +22,17 @@
 static void display_cipher(tm_ssl_session_t ssl);
 static void display_session_id(tm_ssl_session_t ssl);
 
+bool tm_ssl_writeable (tm_ssl_session_t _ssl)
+{
+    /*
+      The `ssl_read` call of axTLS can sometimes be waiting for more data to come in on a subsequent call.
+      Unfortunately, their `ssl_write` call clobbers an important flag (and the underlying buffer), causing
+      subsequent read calls to read encrypted (random) application data as if it were a record header. So…
+    */
+    SSL *ssl = _ssl;      // needed to (ab)use internal macro
+    return IS_SET_SSL_FLAG(SSL_NEED_RECORD);
+}
+
 int tm_ssl_write (tm_ssl_session_t ssl, const uint8_t *buf, size_t *buf_len)
 {
     int res = ssl_write(ssl, buf, *buf_len);

--- a/src/tm_ssl.c
+++ b/src/tm_ssl.c
@@ -22,7 +22,7 @@
 static void display_cipher(tm_ssl_session_t ssl);
 static void display_session_id(tm_ssl_session_t ssl);
 
-bool tm_ssl_writeable (tm_ssl_session_t _ssl)
+int tm_ssl_writeable (tm_ssl_session_t _ssl)
 {
     /*
       The `ssl_read` call of axTLS can sometimes be waiting for more data to come in on a subsequent call.


### PR DESCRIPTION
The axTLS `ssl_write` call can corrupt the state left behind by an `ssl_read` call that is waiting to receive more application data. This delays such calls, by taking advantage of a timeout already in place for postponing data sends.

It also removes some mystery code introduced by https://github.com/tessel/runtime/commit/444e0e01ef6a39ede2f0bc1a7ffc6a61b5904600#diff-a6c0ef0ce02f66377a5f76d111f26168R120 that was trying to prevent some sort of opposite situation — delaying reads while a write was delayed. This caused deadlocks with the new logic for obvious reasons. I cannot think of a reason why reading while outgoing buffers are bouncing around in a `setTimeout` would be troublesome, so I got rid of the old logic.

Fixes the underlying cause of https://github.com/tessel/runtime/issues/709.